### PR TITLE
Correctly escape single quotes in YAML

### DIFF
--- a/Model/File/Writer/YamlWriter.php
+++ b/Model/File/Writer/YamlWriter.php
@@ -110,6 +110,6 @@ class YamlWriter extends AbstractWriter
             return "|\n" . $value;
         }
 
-        return '\'' . addcslashes($value, '\'') . '\'';
+        return '\'' . str_replace('\'', '\'\'', $value) . '\'';
     }
 }


### PR DESCRIPTION
### Issue

Currently single quotes in config values are escaped using backslashes (i.e., `'testing \' 123'`), but this is [not valid YAML](http://yaml.org/spec/current.html#id2534365) and causes Symfony to throw an exception when the values are imported back into the database.

### Proposed changes

Correctly quote single quotes with a repeated single quote (i.e., `'testing '' 123'`).
